### PR TITLE
Fix add card to player hand function

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -6,7 +6,6 @@ const Player = require('./player');
 const Players = require('./players');
 
 const addCardToPlayer = (game, playerId, card) => {
-  console.log('addCardToPlayer', { playerId, card });
   const { players } = game;
   const player = players[playerId];
 
@@ -14,7 +13,7 @@ const addCardToPlayer = (game, playerId, card) => {
     ...game,
     players: {
       ...players,
-      [player.id]: Player.addCards(player, card)
+      [player.id]: Player.addCard(player, card)
     }
   };
 };
@@ -104,7 +103,11 @@ const isCardCanBeThrown = (game, card) => {
 const isDone = game => {
   const { players: playersCollection } = game;
   const players = Object.values(playersCollection);
-  return players.find(Player.isDone);
+  console.log({ players });
+  return players.find(p => {
+    console.log({ p });
+    return Player.isDone(p);
+  });
 };
 
 const mask = game => {

--- a/server/player.js
+++ b/server/player.js
@@ -4,9 +4,7 @@ const Cards = require('./cards');
 
 const addCards = (player, cards) => ({
   ...player,
-  cards,
-  isWatching: null,
-  nbrCardsDiscovered: 0
+  cards
 });
 
 const addCard = (player, cardToAdd) => {
@@ -36,7 +34,7 @@ const create = name => ({
   tmpCard: null // Card the player pick (discard or draw pile)
 });
 
-const isDone = ({ cards }) => cards.every(card => !card);
+const isDone = player => player.cards.every(card => card === null);
 
 const incrementNbrCardsDiscovered = player => ({
   ...player,


### PR DESCRIPTION
The function to give a player one more card (when the player was wrong about his or someone's card) replaced the whole player hand instead. This PR fixes that issue.