### PR TITLE
Card spot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+install:
+	yarn install
+
+run:
+	yarn dev

--- a/components/CardSpot/index.js
+++ b/components/CardSpot/index.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import theme from '../theme';
+import { Column } from '../layout';
+import PlayingCard from '../PlayingCard';
+
+const RelativeWrapper = styled.div`
+  position: relative;
+  box-sizing: border-box;
+`;
+
+const LabelWrapper = styled(Column)`
+  position: absolute;
+  left: 0;
+  right: 0;
+  /* compensate card padding */
+  top: 3px;
+  bottom: 6px;
+  align-items: center;
+  justify-content: center;
+  padding: ${theme.spacing.s1};
+  border: 2px dashed ${theme.color.border};
+  border-radius: 6px;
+  background: ${theme.color.backgroundAccented};
+  text-transform: uppercase;
+  font-size: ${theme.fontSize.larger};
+  font-weight: ${theme.fontWeight.medium};
+  line-height: 1.5;
+  color: ${theme.color.border};
+  text-align: center;
+`;
+
+const HiddenPlayingCard = styled(PlayingCard).attrs({ isHidden: true })`
+  visibility: hidden;
+`;
+
+// export default StyledCardSpot;
+const CardSpot = ({ label }) => {
+  return (
+    <RelativeWrapper>
+      <LabelWrapper>{label}</LabelWrapper>
+      {/* Use an invisible card as background to set width and height */}
+      <HiddenPlayingCard />
+    </RelativeWrapper>
+  );
+};
+
+export default CardSpot;

--- a/components/Game/DiscardPile/index.js
+++ b/components/Game/DiscardPile/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import CardSpot from '../../CardSpot';
 import { Column, Row } from '../../layout';
 import PlayingCard from '../../PlayingCard';
 import { Heading } from '../../text';
@@ -10,8 +11,10 @@ const DiscardPile = ({ discardPile, onDrawDiscarded, onDrawNew }) => {
       <Heading>Discard Pile</Heading>
       <Row spacing="s1_5">
         <PlayingCard isHidden onClick={onDrawNew} />
-        {discardPile && discardPile.length && (
+        {discardPile && discardPile.length ? (
           <PlayingCard card={discardPile[discardPile.length - 1]} onClick={onDrawDiscarded} />
+        ) : (
+          <CardSpot />
         )}
       </Row>
     </Column>

--- a/components/Game/PlayerCards/index.js
+++ b/components/Game/PlayerCards/index.js
@@ -20,12 +20,14 @@ const PlayerCards = ({
             {unfoldedCards[cardPlayerId] && unfoldedCards[cardPlayerId][cardIndex] ? (
               <PlayingCard card={card} onClick={() => onCardHide(cardIndex, cardPlayerId)} />
             ) : (
-              <PlayingCard
-                card={card}
-                isHidden
-                isSelected={selectedCards[cardPlayerId] === cardIndex}
-                onClick={() => onCardPick(cardIndex, cardPlayerId)}
-              />
+              // TEMP: keep cards visibile to ease debugging
+              <div style={{ opacity: 0.15 }}>
+                <PlayingCard
+                  card={card}
+                  isSelected={selectedCards[cardPlayerId] === cardIndex}
+                  onClick={() => onCardPick(cardIndex, cardPlayerId)}
+                />
+              </div>
             )}
           </Fragment>
         ) : (

--- a/components/Game/PlayerCards/index.js
+++ b/components/Game/PlayerCards/index.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 
 import { Row } from '../../layout';
+import CardSpot from '../../CardSpot';
 import PlayingCard from '../../PlayingCard';
 
 const PlayerCards = ({
@@ -27,8 +28,9 @@ const PlayerCards = ({
               />
             )}
           </Fragment>
-        ) : // TODO Render empty spot
-        null
+        ) : (
+          <CardSpot label="No Card" />
+        )
       )}
     </Row>
   );

--- a/components/Game/index.js
+++ b/components/Game/index.js
@@ -16,7 +16,7 @@ const Game = ({ game, playerId }) => {
   const [selectedCards, setSelectedCards] = useState({});
   // Unfolded cards: { [playerId]: { [cardIndex]: boolean }}
   const [unfoldedCards, setUnfoldedCards] = useState({});
-  const { discardPile, id: gameId, name, nextActions, players, isStarted } = game;
+  const { discardPile, id: gameId, name, nextActions, players, isReady, isStarted } = game;
 
   const { tmpCard } = players[playerId];
   const nextAction = nextActions.length && nextActions[0];
@@ -209,16 +209,18 @@ const Game = ({ game, playerId }) => {
         })}
       </div>
 
-      <Row spacing="s8">
-        <DiscardPile
-          discardPile={isStarted ? discardPile : undefined}
-          {...(selfAction === 'pick' && {
-            onDrawDiscarded: handlePickDiscardCard,
-            onDrawNew: handlePickDrawCard
-          })}
-        />
-        <PickedCard card={tmpCard} onClick={handleThrowTmpCard} />
-      </Row>
+      {isReady && (
+        <Row spacing="s8">
+          <DiscardPile
+            discardPile={isStarted ? discardPile : undefined}
+            {...(selfAction === 'pick' && {
+              onDrawDiscarded: handlePickDiscardCard,
+              onDrawNew: handlePickDrawCard
+            })}
+          />
+          <PickedCard card={tmpCard} onClick={handleThrowTmpCard} />
+        </Row>
+      )}
 
       <Column spacing="s1">
         {Object.keys(players).map(pid => {

--- a/components/PlayingCard/index.js
+++ b/components/PlayingCard/index.js
@@ -40,18 +40,16 @@ const StyledImg = styled.img`
     `};
 `;
 
-const PlayingCard = ({ card, isHidden, isSelected, onClick }) => {
+const PlayingCard = ({ card, isHidden, ...rest }) => {
   if (isHidden) {
-    return (
-      <StyledImg isSelected={isSelected} onClick={onClick} src={`/cards/${DECK_COLOR}_back.svg`} />
-    );
+    return <StyledImg {...rest} src={`/cards/${DECK_COLOR}_back.svg`} />;
   }
 
   const { value, suit } = card;
   const suitLetter = SUIT_LETTER[suit];
   const cardId = value === 'Joker' ? 'joker' : `${value}${suitLetter}`;
 
-  return <StyledImg onClick={onClick} src={`/cards/${cardId}.svg`} />;
+  return <StyledImg {...rest} src={`/cards/${cardId}.svg`} />;
 };
 
 export default PlayingCard;

--- a/components/theme.js
+++ b/components/theme.js
@@ -15,21 +15,6 @@ export const color = {
   monza: '#e60c0c' // Red
 };
 
-export const colorForBrand = {
-  primary: color.governorBay,
-  primaryHover: darken(0.05, color.governorBay),
-  primaryActive: darken(0.1, color.governorBay),
-  primaryBackground: tint(0.85, color.governorBay),
-
-  text: color.codGray,
-  textDisabled: color.silver,
-  textHighlighted: color.governorBay,
-  textSubdued: color.dustyGray,
-
-  border: color.mercury,
-  shadow: rgba(color.black, 0.1)
-};
-
 export const colorForStatus = {
   danger: color.monza,
   disabled: color.dustyGray,
@@ -45,7 +30,22 @@ const theme = {
   },
   color: {
     ...color,
-    ...colorForBrand
+
+    primary: color.governorBay,
+    primaryHover: darken(0.05, color.governorBay),
+    primaryActive: darken(0.1, color.governorBay),
+    primaryBackground: tint(0.85, color.governorBay),
+
+    background: color.white,
+    backgroundAccented: color.alabaster,
+
+    text: color.codGray,
+    textDisabled: color.silver,
+    textHighlighted: color.governorBay,
+    textSubdued: color.dustyGray,
+
+    border: color.mercury,
+    shadow: rgba(color.black, 0.1)
   },
   fontSize: {
     small: rem('11px'),


### PR DESCRIPTION
This PR adds a `CardSpot` component to be used when a card deck is empty.

It also makes payer cards visible to ease debugging.


## Preview

### Empty discard pile
![image](https://user-images.githubusercontent.com/7151559/77209560-d5d58880-6afe-11ea-9c52-486f1bc7b0b9.png)

### Empty player card
![image](https://user-images.githubusercontent.com/7151559/77209529-c5bda900-6afe-11ea-8eeb-01af77bbca46.png)


