### PR TITLE
Animate cards

### DIFF
--- a/components/AnimatedPlayingCard/helpers.js
+++ b/components/AnimatedPlayingCard/helpers.js
@@ -1,0 +1,8 @@
+export const getNodesOffset = (selfNode, targetNode) => {
+  const fromRect = selfNode ? selfNode.getBoundingClientRect() : null;
+  const toRect = targetNode ? targetNode.getBoundingClientRect() : null;
+
+  return fromRect && toRect
+    ? { x: toRect.x - fromRect.x, y: toRect.y - fromRect.y }
+    : { x: 0, y: 0 };
+};

--- a/components/AnimatedPlayingCard/index.js
+++ b/components/AnimatedPlayingCard/index.js
@@ -1,0 +1,58 @@
+import React, { useRef, useEffect, useState, memo } from 'react';
+import { animated, useSpring } from 'react-spring';
+import { useWindowSize } from 'react-use';
+
+import useCardSpots, {
+  DRAW_PILE_SPOT_ID,
+  DISCARD_PILE_SPOT_ID,
+  PICKED_CARD_SPOT_ID
+} from '../../hooks/useCardSpots';
+import PlayingCard from '../PlayingCard';
+import { getNodesOffset } from './helpers';
+
+const AnimatedPlayingCard = ({ card, ...rest }) => {
+  const cardRef = useRef();
+  const { cardSpots, getSpotNode } = useCardSpots();
+  const { width, height } = useWindowSize();
+
+  const cardSpot = cardSpots[card.id];
+
+  const originNode = getSpotNode(DRAW_PILE_SPOT_ID);
+  const destinationNode = getSpotNode(cardSpot);
+
+  const [offset, setOffset] = useState(() => getNodesOffset(originNode, destinationNode));
+
+  useEffect(() => {
+    const newOffset = getNodesOffset(originNode, destinationNode);
+    setOffset(newOffset);
+  }, [width, height, cardSpots]);
+
+  const animatedStyle = useSpring({
+    from: { transform: 'translate3d(0px, 0px, 0)' },
+    to: { transform: `translate3d(${offset.x}px, ${offset.y}px, 0)` }
+  });
+
+  const isInDiscardPile = cardSpot === DISCARD_PILE_SPOT_ID;
+  const isInDrawPile = cardSpot === DRAW_PILE_SPOT_ID;
+  const isPickedCard = cardSpot === PICKED_CARD_SPOT_ID;
+
+  const isCardVisible = (isInDiscardPile || isPickedCard) && !isInDrawPile;
+
+  return (
+    <animated.div ref={cardRef} style={animatedStyle}>
+      <PlayingCard
+        card={isInDrawPile ? null : card}
+        isHidden={isInDrawPile}
+        style={{
+          // Delegate click to card spot
+          pointerEvents: 'none',
+          // TEMP debug mode
+          ...(!isCardVisible && { opacity: 0.2 })
+        }}
+        {...rest}
+      />
+    </animated.div>
+  );
+};
+
+export default memo(AnimatedPlayingCard);

--- a/components/CardSpot/index.js
+++ b/components/CardSpot/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 
 import theme from '../theme';
@@ -35,10 +35,9 @@ const HiddenPlayingCard = styled(PlayingCard).attrs({ isHidden: true })`
   visibility: hidden;
 `;
 
-// export default StyledCardSpot;
-const CardSpot = ({ label }) => {
+const CardSpot = ({ label, ...rest }, ref) => {
   return (
-    <RelativeWrapper>
+    <RelativeWrapper ref={ref} {...rest}>
       <LabelWrapper>{label}</LabelWrapper>
       {/* Use an invisible card as background to set width and height */}
       <HiddenPlayingCard />
@@ -46,4 +45,4 @@ const CardSpot = ({ label }) => {
   );
 };
 
-export default CardSpot;
+export default forwardRef(CardSpot);

--- a/components/Game/DiscardPile/_styled.js
+++ b/components/Game/DiscardPile/_styled.js
@@ -1,43 +1,13 @@
 import styled from 'styled-components';
 
-import theme from '../../theme';
-import { DECK_COLOR, StyledImg } from '../../PlayingCard';
-
-export const FailedCard = styled.div``;
-
-export const DiscardPileWrapper = styled.div`
-  position: relative;
-  width: ${theme.metric.cardWidth};
-  height: 100%;
-
-  ${FailedCard} {
-    position: absolute;
-    top: 30%;
-    left: -20%;
-    transform: rotate(-10deg);
-  }
+export const FailedCard = styled.div`
+  position: absolute;
+  z-index: 1;
+  top: 30%;
+  left: -20%;
+  transform: rotate(-10deg);
 `;
 
-export const DrawPile = styled.div`
+export const RelativeWrapper = styled.div`
   position: relative;
-  width: ${theme.metric.cardWidth};
-  height: 100%;
-  background: url('/cards/${DECK_COLOR}_back.svg') no-repeat;
-  background-size: 100% 100%;
-  
-  &:before {
-    content: '';
-    position: absolute;
-    top: -2px;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: inherit;
-    z-index: 0;
-  }
-  
-  ${StyledImg} {
-    position: absolute;
-    top: -5px;
-  }
 `;

--- a/components/Game/DiscardPile/index.js
+++ b/components/Game/DiscardPile/index.js
@@ -1,29 +1,20 @@
 import React from 'react';
 
 import CardSpot from '../../CardSpot';
-import { Row } from '../../layout';
 import PlayingCard from '../../PlayingCard';
-import { DiscardPileWrapper, DrawPile, FailedCard } from './_styled';
+import { FailedCard, RelativeWrapper } from './_styled';
 
-const DiscardPile = ({ discardPile, failedCard, onDrawDiscarded, onPickFailedCard, onDrawNew }) => {
+const DiscardPile = ({ discardPile, failedCard, onPickDiscardedCard, onPickFailedCard }) => {
   return (
-    <Row spacing="s1_5" justifyContent="center">
-      <DiscardPileWrapper>
-        {discardPile && discardPile.length ? (
-          <PlayingCard card={discardPile[discardPile.length - 1]} onClick={onDrawDiscarded} />
-        ) : (
-          <CardSpot />
-        )}
-        {failedCard && (
-          <FailedCard>
-            <PlayingCard card={failedCard.card} onClick={onPickFailedCard} />
-          </FailedCard>
-        )}
-      </DiscardPileWrapper>
-      <DrawPile>
-        <PlayingCard isHidden onClick={onDrawNew} />
-      </DrawPile>
-    </Row>
+    <RelativeWrapper>
+      <CardSpot
+        onClick={onPickDiscardedCard}
+        {...((!discardPile || !discardPile.length) && { style: { opacity: 0 } })}
+      />
+      <FailedCard>
+        {failedCard && <PlayingCard card={failedCard.card} onClick={onPickFailedCard} />}
+      </FailedCard>
+    </RelativeWrapper>
   );
 };
 

--- a/components/Game/DiscardPile/index.js
+++ b/components/Game/DiscardPile/index.js
@@ -1,17 +1,23 @@
 import React from 'react';
 
+import useCardSpots, {
+  DISCARD_PILE_SPOT_ID,
+  FAILED_CARD_SPOT_ID
+} from '../../../hooks/useCardSpots';
 import CardSpot from '../../CardSpot';
 import PlayingCard from '../../PlayingCard';
 import { FailedCard, RelativeWrapper } from './_styled';
 
 const DiscardPile = ({ discardPile, failedCard, onPickDiscardedCard, onPickFailedCard }) => {
+  const { setCardSpotRef } = useCardSpots();
   return (
     <RelativeWrapper>
       <CardSpot
+        ref={setCardSpotRef(DISCARD_PILE_SPOT_ID)}
         onClick={onPickDiscardedCard}
         {...((!discardPile || !discardPile.length) && { style: { opacity: 0 } })}
       />
-      <FailedCard>
+      <FailedCard ref={setCardSpotRef(FAILED_CARD_SPOT_ID)}>
         {failedCard && <PlayingCard card={failedCard.card} onClick={onPickFailedCard} />}
       </FailedCard>
     </RelativeWrapper>

--- a/components/Game/DrawPile/_styled.js
+++ b/components/Game/DrawPile/_styled.js
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+import { DECK_COLOR, StyledImg } from '../../PlayingCard';
+import theme from '../../theme';
+
+export const DrawPileWrapper = styled.div`
+position: relative;
+width: ${theme.metric.cardWidth};
+height: 100%;
+background: url('/cards/${DECK_COLOR}_back.svg') no-repeat;
+background-size: 100% 100%;
+
+&:before {
+  content: '';
+  position: absolute;
+  top: -2px;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: inherit;
+  z-index: 0;
+}
+
+${StyledImg} {
+  position: absolute;
+  top: -5px;
+}
+`;

--- a/components/Game/DrawPile/index.js
+++ b/components/Game/DrawPile/index.js
@@ -1,14 +1,17 @@
 import React from 'react';
 
 import useCardSpots, { DRAW_PILE_SPOT_ID } from '../../../hooks/useCardSpots';
+import AnimatedPlayingCard from '../../AnimatedPlayingCard';
 import PlayingCard from '../../PlayingCard';
 import { DrawPileWrapper } from './_styled';
 
-const DrawPile = ({ onDraw }) => {
+const DrawPile = ({ cards, onDraw }) => {
   const { setCardSpotRef } = useCardSpots();
 
   return (
     <DrawPileWrapper ref={setCardSpotRef(DRAW_PILE_SPOT_ID)}>
+      {/* Render every card on the draw pile, and position them to the right spot with CSS */}
+      {!!cards && cards.map(card => card && <AnimatedPlayingCard key={card.id} card={card} />)}
       <PlayingCard isHidden onClick={onDraw} />
     </DrawPileWrapper>
   );

--- a/components/Game/DrawPile/index.js
+++ b/components/Game/DrawPile/index.js
@@ -1,11 +1,14 @@
 import React from 'react';
 
+import useCardSpots, { DRAW_PILE_SPOT_ID } from '../../../hooks/useCardSpots';
 import PlayingCard from '../../PlayingCard';
 import { DrawPileWrapper } from './_styled';
 
 const DrawPile = ({ onDraw }) => {
+  const { setCardSpotRef } = useCardSpots();
+
   return (
-    <DrawPileWrapper>
+    <DrawPileWrapper ref={setCardSpotRef(DRAW_PILE_SPOT_ID)}>
       <PlayingCard isHidden onClick={onDraw} />
     </DrawPileWrapper>
   );

--- a/components/Game/DrawPile/index.js
+++ b/components/Game/DrawPile/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import PlayingCard from '../../PlayingCard';
+import { DrawPileWrapper } from './_styled';
+
+const DrawPile = ({ onDraw }) => {
+  return (
+    <DrawPileWrapper>
+      <PlayingCard isHidden onClick={onDraw} />
+    </DrawPileWrapper>
+  );
+};
+
+export default DrawPile;

--- a/components/Game/PickedCard/index.js
+++ b/components/Game/PickedCard/index.js
@@ -1,15 +1,15 @@
 import React from 'react';
 
-import PlayingCard from '../../PlayingCard';
-import { PickedCardWrapper } from './_styled';
+import useCardSpots, { PICKED_CARD_SPOT_ID } from '../../../hooks/useCardSpots';
+import CardSpot from '../../CardSpot';
 
-const PickedCard = ({ card, className, onClick }) => {
+const PickedCard = ({ onClick }) => {
+  const { setCardSpotRef } = useCardSpots();
+
   return (
-    card && (
-      <PickedCardWrapper>
-        <PlayingCard className={className} card={card} onClick={onClick} />
-      </PickedCardWrapper>
-    )
+    <div ref={setCardSpotRef(PICKED_CARD_SPOT_ID)}>
+      <CardSpot style={{ opacity: 0 }} onClick={onClick} />
+    </div>
   );
 };
 

--- a/components/Game/PlayerCards/index.js
+++ b/components/Game/PlayerCards/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { Row } from '../../layout';
+import useCardSpots, { getPlayerCardSpotId } from '../../../hooks/useCardSpots';
 import CardSpot from '../../CardSpot';
+import { Row } from '../../layout';
 import PlayingCard from '../../PlayingCard';
-
 import { CardInfo, CardWrapper } from './_styled';
 
 const PlayerCards = ({
@@ -15,30 +15,32 @@ const PlayerCards = ({
   shouldRevealAllCards,
   unfoldedCards
 }) => {
+  const { setCardSpotRef } = useCardSpots();
+
   return (
     <Row spacing="s1_5">
-      {cards.map((card, cardIndex) =>
-        card ? (
-          <CardWrapper key={cardIndex}>
-            {(unfoldedCards[cardPlayerId] && unfoldedCards[cardPlayerId][cardIndex]) ||
-            shouldRevealAllCards ? (
-              <PlayingCard card={card} onClick={() => onCardHide(cardIndex, cardPlayerId)} />
-            ) : (
-              // TEMP: keep cards visibile to ease debugging
-              <div style={{ opacity: 0.15 }}>
-                {card.metadata.isBeingWatched && <CardInfo>Being watched</CardInfo>}
-                <PlayingCard
-                  card={card}
-                  isSelected={selectedCards[cardPlayerId] === cardIndex}
-                  onClick={() => onCardPick(cardIndex, cardPlayerId)}
-                />
-              </div>
-            )}
-          </CardWrapper>
-        ) : (
-          <CardSpot key={cardIndex} label="No Card" />
-        )
-      )}
+      {cards.map((card, cardIndex) => (
+        <div key={cardIndex} ref={setCardSpotRef(getPlayerCardSpotId(cardPlayerId, cardIndex))}>
+          {card ? (
+            <CardWrapper>
+              {(unfoldedCards[cardPlayerId] && unfoldedCards[cardPlayerId][cardIndex]) ||
+              shouldRevealAllCards ? (
+                <PlayingCard card={card} onClick={() => onCardHide(cardIndex, cardPlayerId)} />
+              ) : (
+                <>
+                  {card.metadata.isBeingWatched && <CardInfo>Being watched</CardInfo>}
+                  <CardSpot
+                    style={{ opacity: 0 }}
+                    onClick={() => onCardPick(cardIndex, cardPlayerId)}
+                  />
+                </>
+              )}
+            </CardWrapper>
+          ) : (
+            <CardSpot label="No Card" />
+          )}
+        </div>
+      ))}
     </Row>
   );
 };

--- a/components/Game/index.js
+++ b/components/Game/index.js
@@ -15,12 +15,12 @@ import Scoreboard from './Scoreboard';
 const Game = () => {
   const { handleTriggerCaracole, game, selfId, selectedCards, unfoldedCards } = useGame();
   const {
-    handleCardClick,
     handleHideCard,
     handlePickDrawCard,
     handlePickDrawCardAfterFail,
     handlePickDiscardedCard,
     handlePickFailedCard,
+    handlePlayerCardClick,
     handlePlayerReady,
     handleThrowTmpCard,
     isSelfToPlay,
@@ -62,7 +62,7 @@ const Game = () => {
           cardPlayerId={player.id}
           cards={player.cards}
           onCardHide={handleHideCard}
-          onCardPick={handleCardClick}
+          onCardPick={handlePlayerCardClick}
           selectedCards={selectedCards}
           shouldRevealAllCards={!isReady}
           unfoldedCards={unfoldedCards}

--- a/components/Game/index.js
+++ b/components/Game/index.js
@@ -28,7 +28,16 @@ const Game = () => {
     nextPlayer
   } = useCardActions();
 
-  const { cardBeingWatched, discardPile, failedCard, name, players, isReady, isStarted } = game;
+  const {
+    cards,
+    cardBeingWatched,
+    discardPile,
+    failedCard,
+    name,
+    players,
+    isReady,
+    isStarted
+  } = game;
 
   const selfPlayer = Object.values(players).find(p => p.id === selfId) || {};
   const otherPlayers = Object.values(players).filter(p => p.id !== selfId) || [];

--- a/components/Game/index.js
+++ b/components/Game/index.js
@@ -7,10 +7,10 @@ import Button from '../Button';
 import DiscardPile from './DiscardPile';
 import useGame from '../../hooks/useGame';
 import useCardActions from '../../hooks/useCardActions';
+import DrawPile from './DrawPile';
 import PickedCard from './PickedCard';
 import PlayerCards from './PlayerCards';
 import Scoreboard from './Scoreboard';
-import { RelativeRow } from './_styled';
 
 const Game = () => {
   const { handleTriggerCaracole, game, selfId, selectedCards, unfoldedCards } = useGame();
@@ -19,7 +19,7 @@ const Game = () => {
     handleHideCard,
     handlePickDrawCard,
     handlePickDrawCardAfterFail,
-    handlePickDiscardCard,
+    handlePickDiscardedCard,
     handlePickFailedCard,
     handlePlayerReady,
     handleThrowTmpCard,
@@ -102,26 +102,34 @@ const Game = () => {
               </>
             )}
           </Column>
-          <RelativeRow justifyContent="center">
+          <Row justifyContent="center" spacing="s4">
             <PickedCard card={tmpCard} onClick={handleThrowTmpCard} />
-            <DiscardPile
-              discardPile={isStarted ? discardPile : undefined}
-              failedCard={failedCard}
-              {...(isSelfToPlay &&
-                nextAction === 'pick' && {
-                  onDrawDiscarded: handlePickDiscardCard,
-                  onDrawNew: handlePickDrawCard
-                })}
-              {...(isSelfToPlay &&
-                nextAction === 'pickFailed' && {
-                  onPickFailedCard: handlePickFailedCard
-                })}
-              {...(isSelfToPlay &&
-                nextAction === 'pickDrawAfterFail' && {
-                  onDrawNew: handlePickDrawCardAfterFail
-                })}
-            />
-          </RelativeRow>
+            <Row spacing="s1_5" justifyContent="center">
+              <DiscardPile
+                pickedCard={tmpCard}
+                discardPile={isStarted ? discardPile : undefined}
+                failedCard={failedCard}
+                players={players}
+                {...(isSelfToPlay &&
+                  nextAction === 'pick' && {
+                    onPickDiscardedCard: handlePickDiscardedCard
+                  })}
+                {...(isSelfToPlay &&
+                  nextAction === 'pickFailed' && {
+                    onPickFailedCard: handlePickFailedCard
+                  })}
+              />
+              <DrawPile
+                cards={cards}
+                onDraw={
+                  (isSelfToPlay &&
+                    ((nextAction === 'pick' && handlePickDrawCard) ||
+                      (nextAction === 'pickDrawAfterFail' && handlePickDrawCardAfterFail))) ||
+                  undefined
+                }
+              />
+            </Row>
+          </Row>
           <Row justifyContent="center">
             <Scoreboard players={players}>
               {({ open }) => <Link onClick={open}>see scores</Link>}

--- a/components/PlayingCard/index.js
+++ b/components/PlayingCard/index.js
@@ -13,6 +13,7 @@ const SUIT_LETTER = {
 };
 
 export const StyledImg = styled.img`
+  display: block;
   width: ${theme.metric.cardWidth};
   height: calc(${theme.metric.cardWidth} * 1.4);
   border-radius: ${theme.metric.borderRadius};
@@ -41,7 +42,7 @@ export const StyledImg = styled.img`
 `;
 
 const PlayingCard = ({ card, isHidden, ...rest }) => {
-  if (isHidden) {
+  if (isHidden || !card) {
     return <StyledImg {...rest} src={`/cards/${DECK_COLOR}_back.svg`} />;
   }
 

--- a/hooks/useCardActions.js
+++ b/hooks/useCardActions.js
@@ -84,9 +84,9 @@ const useCardActions = () => {
     socket.emit('game.pickDrawCardAfterFail', { gameId, playerId: selfId });
   };
 
-  const handlePickDiscardCard = () => {
-    console.log('handlePickDiscardCard');
-    socket.emit('game.pickDiscardCard', { gameId, playerId: selfId });
+  const handlePickDiscardedCard = () => {
+    console.log('handlePickDiscardedCard');
+    socket.emit('game.pickDiscardedCard', { gameId, playerId: selfId });
   };
 
   const handlePickFailedCard = () => {
@@ -119,7 +119,7 @@ const useCardActions = () => {
     revealCard(cardIndex, cardPlayerId);
   };
 
-  const handleCardClick = (cardIndex, cardPlayerId) => {
+  const handlePlayerCardClick = (cardIndex, cardPlayerId) => {
     const isSelf = cardPlayerId === selfId;
 
     // Game hasn't start
@@ -150,12 +150,12 @@ const useCardActions = () => {
   };
 
   return {
-    handleCardClick,
     handleHideCard,
     handlePickDrawCard,
     handlePickDrawCardAfterFail,
-    handlePickDiscardCard,
+    handlePickDiscardedCard,
     handlePickFailedCard,
+    handlePlayerCardClick,
     handlePlayerReady,
     handleThrowTmpCard,
     isSelfToPlay,

--- a/hooks/useCardSpots.js
+++ b/hooks/useCardSpots.js
@@ -1,0 +1,86 @@
+import { useCallback, useContext, createContext, useRef, useState, useEffect } from 'react';
+import useGame from './useGame';
+
+export const DISCARD_PILE_SPOT_ID = 'discard-pile';
+export const DRAW_PILE_SPOT_ID = 'draw-pile';
+export const FAILED_CARD_SPOT_ID = 'failed-card';
+export const PICKED_CARD_SPOT_ID = 'picked-card';
+
+export const getPlayerCardSpotId = (playerId, spotIndex) => `player${playerId}_${spotIndex}`;
+
+const CardSpotsContext = createContext(null);
+
+export const CardSpotsProvider = ({ children }) => {
+  const { game, selfId } = useGame();
+  const [cardSpots, setCardSpots] = useState({}); // { [cardId]: spotId }
+  const cardSpotsRef = useRef({}); // { [spotId]: HTLMElement }
+
+  const getSpotNode = useCallback(spotId => cardSpotsRef.current[spotId], [cardSpotsRef]);
+
+  const setCardSpotRef = useCallback(
+    spotId => node => {
+      cardSpotsRef.current[spotId] = node;
+    },
+    [cardSpotsRef]
+  );
+
+  const { cards, discardPile, failedCard, players } = game || {};
+
+  useEffect(() => {
+    if (cards) {
+      // Flatten player cards in a object { [cardId]: spotId }
+      const playerCardSpots = Object.values(players).reduce(
+        (playersAcc, { cards, id: playerID }) => {
+          const singlePlayerCardSpots = cards.reduce((cardsAcc, card, spotIndex) => {
+            return {
+              ...cardsAcc,
+              ...(card && { [card.id]: getPlayerCardSpotId(playerID, spotIndex) })
+            };
+          }, {});
+
+          return {
+            ...playersAcc,
+            ...singlePlayerCardSpots
+          };
+        },
+        {}
+      );
+
+      const discardedCard = discardPile && [...discardPile].pop();
+      const { tmpCard: pickedCard } = Object.values(players).find(p => p.id === selfId) || {};
+
+      const drawPileCards = Object.values(cards || []).reduce(
+        (acc, { id }) => ({ ...acc, [id]: DRAW_PILE_SPOT_ID }),
+        {}
+      );
+
+      const newCardSpots = {
+        ...drawPileCards,
+        ...playerCardSpots,
+        ...(discardedCard && { [discardedCard.id]: DISCARD_PILE_SPOT_ID }),
+        ...(failedCard && { [failedCard.id]: FAILED_CARD_SPOT_ID }),
+        ...(pickedCard && { [pickedCard.id]: PICKED_CARD_SPOT_ID })
+      };
+      setCardSpots(newCardSpots);
+    }
+  }, [discardPile, players]);
+
+  const value = {
+    cardSpots,
+    getSpotNode,
+    setCardSpotRef
+  };
+
+  return <CardSpotsContext.Provider value={value}>{children}</CardSpotsContext.Provider>;
+};
+
+const useCardSpots = () => {
+  const cardSpotsContext = useContext(CardSpotsContext);
+  if (!cardSpotsContext) {
+    throw Error('You should not use useGame outside a CardSpotsProvider');
+  }
+
+  return cardSpotsContext;
+};
+
+export default useCardSpots;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "polished": "^3.4.4",
     "react": "16.13.0",
     "react-dom": "16.13.0",
+    "react-spring": "^8.0.27",
+    "react-use": "^13.27.1",
     "socket.io": "^2.3.0",
     "socket.io-client": "^2.3.0",
     "styled-components": "^5.0.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,6 +5,7 @@ import io from 'socket.io-client';
 import { createGlobalStyle } from 'styled-components';
 
 import GameProvider from '../hooks/GameProvider';
+import { CardSpotsProvider } from '../hooks/useCardSpots';
 
 // Override global style to avoid Story height to be 100% of the screen height
 const GlobalStyle = createGlobalStyle`
@@ -51,7 +52,9 @@ class MyApp extends App {
       <>
         <GlobalStyle />
         <GameProvider>
-          <Component {...pageProps} socket={this.state.socket} />
+          <CardSpotsProvider>
+            <Component {...pageProps} socket={this.state.socket} />
+          </CardSpotsProvider>
         </GameProvider>
       </>
     );

--- a/server/game.js
+++ b/server/game.js
@@ -456,6 +456,7 @@ const setup = game => {
 
   return {
     ...game,
+    cards: shuffledDeck,
     discardPile: [
       {
         ...discardPile[0],

--- a/server/index.js
+++ b/server/index.js
@@ -143,8 +143,8 @@ io.on('connection', socket => {
     sendGameUpdateToClients(gameId);
   });
 
-  socket.on('game.pickDiscardCard', ({ gameId, playerId }) => {
-    console.log('game.pickDiscardCard', { gameId, playerId });
+  socket.on('game.pickDiscardedCard', ({ gameId, playerId }) => {
+    console.log('game.pickDiscardedCard', { gameId, playerId });
     let game = FakeDB.getGame(gameId);
     const [card] = game.discardPile.slice(-1);
     game = Game.removeDiscardCard(game);

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,6 +877,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
+  integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.4":
   version "7.8.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
@@ -971,6 +978,11 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/js-cookie@2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.5.tgz#38dfaacae8623b37cc0b0d27398e574e3fc28b1e"
+  integrity sha512-cpmwBRcHJmmZx0OGU7aPVwGWGbs4iKwVYchk9iuMtxNCA2zorwdaTz4GkLgs2WGxiRZRFKnV1k6tRUHX7tBMxg==
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -1117,6 +1129,11 @@
     "@webassemblyjs/ast" "1.8.5"
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
+
+"@xobotyi/scrollbar-width@1.9.5":
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz#80224a6919272f405b87913ca13b92929bdf3c4d"
+  integrity sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -1605,6 +1622,11 @@ body-parser@1.19.0:
     qs "6.7.0"
     raw-body "2.4.0"
     type-is "~1.6.17"
+
+bowser@^1.7.3:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.4.tgz#890c58a2813a9d3243704334fa81b96a5c150c9a"
+  integrity sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ==
 
 boxen@^1.2.1:
   version "1.3.0"
@@ -2238,6 +2260,13 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-to-clipboard@^3.2.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
+  integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 core-js-compat@^3.1.1:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.6.4.tgz#938476569ebb6cda80d339bcf199fae4f16fff17"
@@ -2374,6 +2403,14 @@ css-has-pseudo@^0.10.0:
     postcss "^7.0.6"
     postcss-selector-parser "^5.0.0-rc.4"
 
+css-in-js-utils@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
+  integrity sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+    isobject "^3.0.1"
+
 css-loader@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.3.0.tgz#65f889807baec3197313965d6cda9899f936734d"
@@ -2407,6 +2444,14 @@ css-to-react-native@^3.0.0:
     camelize "^1.0.0"
     css-color-keywords "^1.0.0"
     postcss-value-parser "^4.0.2"
+
+css-tree@^1.0.0-alpha.28:
+  version "1.0.0-alpha.39"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.39.tgz#2bff3ffe1bb3f776cf7eefd91ee5cba77a149eeb"
+  integrity sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==
+  dependencies:
+    mdn-data "2.0.6"
+    source-map "^0.6.1"
 
 css@2.2.4, css@^2.0.0:
   version "2.2.4"
@@ -2447,6 +2492,11 @@ cssnano-simple@1.0.0:
   dependencies:
     cssnano-preset-simple "^1.0.0"
     postcss "^7.0.18"
+
+csstype@^2.5.5:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
+  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -2806,6 +2856,13 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-stack-parser@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.6.tgz#5a99a707bd7a4c58a797902d48d82803ede6aad8"
+  integrity sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==
+  dependencies:
+    stackframe "^1.1.1"
+
 es-abstract@^1.17.0, es-abstract@^1.17.0-next.1:
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
@@ -3163,6 +3220,16 @@ fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-shallow-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz#d4dcaf6472440dcefa6f88b98e3251e27f25628b"
+  integrity sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==
+
+fastest-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fastest-stable-stringify/-/fastest-stable-stringify-1.0.1.tgz#9122d406d4c9d98bea644a6b6853d5874b87b028"
+  integrity sha1-kSLUBtTJ2YvqZEpraFPVh0uHsCg=
 
 figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -3684,6 +3751,11 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+hyphenate-style-name@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
+  integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -3805,6 +3877,14 @@ ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+inline-style-prefixer@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-4.0.2.tgz#d390957d26f281255fe101da863158ac6eb60911"
+  integrity sha512-N8nVhwfYga9MiV9jWlwfdj1UDIaZlBFu4cJSJkIr7tZX7sHpHhGR5su1qdpW+7KPL8ISTvCIkcaFi/JdBknvPg==
+  dependencies:
+    bowser "^1.7.3"
+    css-in-js-utils "^2.0.0"
 
 inquirer@^7.0.0:
   version "7.1.0"
@@ -4143,6 +4223,11 @@ jest-worker@24.9.0:
   dependencies:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
+
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 js-levenshtein@^1.1.3:
   version "1.1.6"
@@ -4523,6 +4608,11 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+mdn-data@2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.6.tgz#852dc60fcaa5daa2e8cf6c9189c440ed3e042978"
+  integrity sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA==
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -4727,6 +4817,20 @@ nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
+nano-css@^5.2.1:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/nano-css/-/nano-css-5.3.0.tgz#9d3cd29788d48b6a07f52aa4aec7cf4da427b6b5"
+  integrity sha512-uM/9NGK9/E9/sTpbIZ/bQ9xOLOIHZwrrb/CRlbDHBU/GFS7Gshl24v/WJhwsVViWkpOXUmiZ66XO7fSB4Wd92Q==
+  dependencies:
+    css-tree "^1.0.0-alpha.28"
+    csstype "^2.5.5"
+    fastest-stable-stringify "^1.0.1"
+    inline-style-prefixer "^4.0.0"
+    rtl-css-js "^1.9.0"
+    sourcemap-codec "^1.4.1"
+    stacktrace-js "^2.0.0"
+    stylis "3.5.0"
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -5868,7 +5972,7 @@ prop-types-exact@1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.7.2, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -6045,6 +6149,33 @@ react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
   integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
+react-spring@^8.0.27:
+  version "8.0.27"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.27.tgz#97d4dee677f41e0b2adcb696f3839680a3aa356a"
+  integrity sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    prop-types "^15.5.8"
+
+react-use@^13.27.1:
+  version "13.27.1"
+  resolved "https://registry.yarnpkg.com/react-use/-/react-use-13.27.1.tgz#e2ae2b708dafc7893c4772628801589aab9de370"
+  integrity sha512-bAwdqDMXs5lovEanXnL1izledfrPEUUv1afoTVB59eUiYcDyKul+M/dT/2WcgHjoY/R6QlrTcZoW4R7ifwvBfw==
+  dependencies:
+    "@types/js-cookie" "2.2.5"
+    "@xobotyi/scrollbar-width" "1.9.5"
+    copy-to-clipboard "^3.2.0"
+    fast-deep-equal "^3.1.1"
+    fast-shallow-equal "^1.0.0"
+    js-cookie "^2.2.1"
+    nano-css "^5.2.1"
+    resize-observer-polyfill "^1.5.1"
+    screenfull "^5.0.0"
+    set-harmonic-interval "^1.0.1"
+    throttle-debounce "^2.1.0"
+    ts-easing "^0.2.0"
+    tslib "^1.10.0"
+
 react@16.13.0:
   version "16.13.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.0.tgz#d046eabcdf64e457bbeed1e792e235e1b9934cf7"
@@ -6217,6 +6348,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
@@ -6316,6 +6452,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rtl-css-js@^1.9.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.14.0.tgz#daa4f192a92509e292a0519f4b255e6e3c076b7d"
+  integrity sha512-Dl5xDTeN3e7scU1cWX8c9b6/Nqz3u/HgR4gePc1kWXYiQWVQbKCEyK6+Hxve9LbcJ5EieHy1J9nJCN3grTtGwg==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+
 run-async@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.0.tgz#e59054a5b86876cfae07f431d18cbaddc594f1e8"
@@ -6403,6 +6546,11 @@ schema-utils@^2.0.0, schema-utils@^2.0.1, schema-utils@^2.6.0, schema-utils@^2.6
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
+screenfull@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.0.2.tgz#b9acdcf1ec676a948674df5cd0ff66b902b0bed7"
+  integrity sha512-cCF2b+L/mnEiORLN5xSAz6H3t18i2oHh9BA8+CQlAh5DRw2+NFAGQJOSYbcGw8B2k04g/lVvFcfZ83b3ysH5UQ==
+
 semver-diff@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
@@ -6458,6 +6606,11 @@ serve-static@1.14.1:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.17.1"
+
+set-harmonic-interval@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz#e1773705539cdfb80ce1c3d99e7f298bb3995249"
+  integrity sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
@@ -6659,6 +6812,11 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
+
 source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
@@ -6673,6 +6831,11 @@ source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+
+sourcemap-codec@^1.4.1:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spdx-correct@^3.0.0:
   version "3.1.0"
@@ -6718,6 +6881,35 @@ ssri@^6.0.1:
   integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
   dependencies:
     figgy-pudding "^3.5.1"
+
+stack-generator@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.5.tgz#fb00e5b4ee97de603e0773ea78ce944d81596c36"
+  integrity sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==
+  dependencies:
+    stackframe "^1.1.1"
+
+stackframe@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.1.1.tgz#ffef0a3318b1b60c3b58564989aca5660729ec71"
+  integrity sha512-0PlYhdKh6AfFxRyK/v+6/k+/mMfyiEBbTM5L94D0ZytQnJ166wuwoTYLHFWGbs2dpA8Rgq763KGWmN1EQEYHRQ==
+
+stacktrace-gps@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz#7688dc2fc09ffb3a13165ebe0dbcaf41bcf0c69a"
+  integrity sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==
+  dependencies:
+    source-map "0.5.6"
+    stackframe "^1.1.1"
+
+stacktrace-js@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-2.0.2.tgz#4ca93ea9f494752d55709a081d400fdaebee897b"
+  integrity sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==
+  dependencies:
+    error-stack-parser "^2.0.6"
+    stack-generator "^2.0.5"
+    stacktrace-gps "^3.0.4"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -6933,6 +7125,11 @@ stylis-rule-sheet@0.0.10:
   resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
   integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
 
+stylis@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
+  integrity sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw==
+
 stylis@3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
@@ -7033,6 +7230,11 @@ thread-loader@2.1.3:
     loader-utils "^1.1.0"
     neo-async "^2.6.0"
 
+throttle-debounce@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
+  integrity sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==
+
 through2@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
@@ -7117,6 +7319,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
+
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
@@ -7133,6 +7340,11 @@ traverse@0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
   integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
+
+ts-easing@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ts-easing/-/ts-easing-0.2.0.tgz#c8a8a35025105566588d87dbda05dd7fbfa5a4ec"
+  integrity sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==
 
 ts-pnp@^1.1.2:
   version "1.1.6"


### PR DESCRIPTION
This PR adds cards animation. 

- the `useCardSpots` hook maintains a ref of every card spots of the board, and tells which card should go to which spot;
- the `AnimatedPlayingCard` component animates every card from the _Draw Pile_ to its card spot;
- for now clicks are still handled by the card spot, and not the card itself;
- for now the _Picked Card_ is a simple card spot (and the CSS-transformed version unfortunately 😞).

### Next steps
- use card metadata to select card spot (we need the backend to update a cards array on every player interaction);
- make every card handle clicks on its own;
- keep discarded cards on _Discard Pile_ (instead of _Draw Pile_);
- support _Failed Card_ spot;
- allow card spots to use CSS-transform, and animate card to that CSS-transformation (to revive the _Picked Card_ style);
- animate card flip;
- manage cards' z-indexes (in the _Draw Pile_ and _Discard Pile_).


### Preview 

![animate-cards](https://user-images.githubusercontent.com/7151559/78610133-80baa600-7864-11ea-8c15-78978463ef48.gif)
