### PR TITLE
Remove card actions for card picked from discard pile

### DIFF
--- a/components/AnimatedPlayingCard/helpers.js
+++ b/components/AnimatedPlayingCard/helpers.js
@@ -2,8 +2,6 @@ export const getNodesOffset = (selfNode, targetNode) => {
   const fromRect = selfNode ? selfNode.getBoundingClientRect() : null;
   const toRect = targetNode ? targetNode.getBoundingClientRect() : null;
 
-  console.log({ toRect });
-
   return fromRect && toRect
     ? {
         x: toRect.x + toRect.width * 0.5 - (fromRect.x + fromRect.width * 0.5), // toRect.x - toRect.width * 0.5 - fromRect.x + fromRect.width * 0.5,

--- a/components/Game/DrawPile/_styled.js
+++ b/components/Game/DrawPile/_styled.js
@@ -7,18 +7,29 @@ export const DrawPileWrapper = styled.div`
   position: relative;
   width: ${theme.metric.cardWidth};
   height: 100%;
-  background: url('/cards/${DECK_COLOR}_back.svg') no-repeat;
-  background-size: 100% 100%;
+  top:-4px;
 
-/* 
   &:before {
     content: '';
     position: absolute;
-    top: -2px;
+    top: 4px;
     left: 0;
     width: 100%;
     height: 100%;
-    background: inherit;
+    background: url('/cards/${DECK_COLOR}_back.svg') no-repeat;
+    background-size: 100% 100%;
     z-index: 0;
-  } */
+  }
+
+  &:after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: url('/cards/${DECK_COLOR}_back.svg') no-repeat;
+    background-size: 100% 100%;
+    z-index: 0;
+  }
 `;

--- a/components/PlayingCard/_styled.js
+++ b/components/PlayingCard/_styled.js
@@ -25,7 +25,6 @@ export const PlayingCardInner = styled.div`
   border-radius: ${theme.metric.borderRadius};
   transition: transform 0.4s ease-in-out;
   transform-style: preserve-3d;
-  cursor: pointer;
   will-change: transform;
 
   ${props =>
@@ -72,6 +71,7 @@ export const PlayingCardWrapper = styled.div`
     props.onClick &&
     css`
       &:hover {
+        cursor: pointer;
         box-shadow: 2px 8px 10px ${theme.color.shadow};
         transform: scale(1.05);
         transition: transform 0.2s ease-out;

--- a/hooks/useCardActions.js
+++ b/hooks/useCardActions.js
@@ -52,7 +52,7 @@ export const CardActionsProvider = ({ children }) => {
 
     if (!isStarted) {
       // Player can only watch their own cards at the beginning
-      if (isSelf) {
+      if (card.spot === `player${selfId}_1` || card.spot === `player${selfId}_3`) {
         const isCardRevealed = !!unfoldedCards.find(unfoldedCard => unfoldedCard.id === card.id);
         if (isCardRevealed) {
           if (unfoldedCardsCount === 1 && discoveredCardsCount === DISCOVERY_CARDS_COUNT) {

--- a/hooks/useCardActions.js
+++ b/hooks/useCardActions.js
@@ -101,7 +101,6 @@ export const CardActionsProvider = ({ children }) => {
       }
 
       if (nextAction === 'watch') {
-        console.log({ unfoldedCardsCount });
         return !unfoldedCardsCount ? handleWatchCard(card) : handleHasWatchedCard(card);
       }
     }

--- a/server/index.js
+++ b/server/index.js
@@ -139,7 +139,7 @@ io.on('connection', socket => {
   socket.on('game.playerPickDrawCard', ({ gameId, playerId }) => {
     let game = FakeDB.getGame(gameId);
     const [drawCard] = game.drawPile;
-    game = Game.removeDrawCard(game, drawCard.id);
+    // game = Game.removeDrawCard(game, drawCard.id);
     game = Game.setCardAsPickedCard(game, playerId, drawCard.id);
     // Save
     FakeDB.saveGame(game);
@@ -159,7 +159,7 @@ io.on('connection', socket => {
   socket.on('game.playerPickDiscardCard', ({ gameId, playerId }) => {
     let game = FakeDB.getGame(gameId);
     const [discardCard] = game.discardPile.slice(-1);
-    game = Game.removeDiscardCard(game);
+    // game = Game.removeDiscardCard(game);
     game = Game.setCardAsPickedCard(game, playerId, discardCard.id);
     // Save
     FakeDB.saveGame(game);


### PR DESCRIPTION
This PR removes actions from card picked from the discard pile and thrown afterward. 
It also restores the pile design under the draw pile.
And finally, the hover/onClick effect is now only on cards the player can play!