### PR TITLE
Fix joker id & swap/exchange action

### DIFF
--- a/components/PlayingCard/_styled.js
+++ b/components/PlayingCard/_styled.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 
 import theme from '../theme';
 
@@ -17,6 +17,15 @@ export const FrontCard = styled(StyledImg)`
 `;
 
 export const BackCard = styled(StyledImg)``;
+
+const shakingAnimation = keyframes`
+	0% {
+    transform: rotate(-1deg);
+	}
+	50% {
+    transform: rotate(1deg);
+	}
+`;
 
 export const PlayingCardInner = styled.div`
   height: 100%;
@@ -81,12 +90,14 @@ export const PlayingCardWrapper = styled.div`
   ${props =>
     props.isSelected &&
     css`
-      transform: scale(1.1);
-      box-shadow: 0 0 2px 2px ${theme.color.governorBay};
+      transform: scale(1.04);
+
+      ${PlayingCardInner} {
+        animation: ${shakingAnimation} 0.3s ease-in-out infinite;
+      }
 
       &:hover {
-        box-shadow: 2px 8px 10px ${theme.color.shadow};
-        transform: scale(1.15);
+        transform: scale(1.1);
       }
     `}
   

--- a/components/PlayingCard/index.js
+++ b/components/PlayingCard/index.js
@@ -64,14 +64,11 @@ const PlayingCard = ({ card, className, isRotated = false }) => {
     <PlayingCardWrapper
       className={className}
       isRotated={isRotated}
+      isSelected={isSelected}
+      isFailedCard={isFailedCard}
       {...(canPlay ? { onClick: () => handleCardClick(card) } : {})}
     >
-      <PlayingCardInner
-        isFailed={isFailedCard}
-        isHidden={!isCardVisible}
-        isPicked={isPickedCard}
-        isSelected={isSelected}
-      >
+      <PlayingCardInner isHidden={!isCardVisible}>
         <StyledImg src={`/cards/${DECK_COLOR}_back.svg`} />
         <FrontCard src={`/cards/${cardId}.svg`} />
       </PlayingCardInner>

--- a/hooks/useGame.js
+++ b/hooks/useGame.js
@@ -60,8 +60,9 @@ export const GameProvider = ({ children }) => {
 
   const selectCard = (card, action) => {
     const { id: cardId, belongsTo } = card;
+
     // Cannot select his own cards on joker action
-    if (action.action === 'swap' && belongsTo === selfId) {
+    if (action === 'swap' && belongsTo === selfId) {
       return;
     }
 
@@ -81,6 +82,16 @@ export const GameProvider = ({ children }) => {
           selectedCard.id === cardOfPlayerAlreadySelected.id ? card : selectedCard
         )
       );
+    }
+
+    // If player must select one of his card in exchange action
+    if (
+      action === 'exchange' &&
+      selectedCards.length &&
+      !selectedCards.find(c => c.belongsTo === selfId) &&
+      belongsTo !== selfId
+    ) {
+      return;
     }
     // Add
     return setSelectedCards([...selectedCards, card]);

--- a/server/cards.js
+++ b/server/cards.js
@@ -33,15 +33,15 @@ const getDeck = (withJoker = true) => {
       deck.push(card);
     }
   }
-  if (withJoker) {
-    const joker = {
-      id: uuidv4(),
-      value: 'Joker',
-      suit: null,
-      points: 10
-    };
-    deck.push(joker, joker);
-  }
+  // if (withJoker) {
+  //   const joker = {
+  //     id: uuidv4(),
+  //     value: 'Joker',
+  //     suit: null,
+  //     points: 10
+  //   };
+  //   deck.push(joker, joker);
+  // }
 
   return deck;
 };

--- a/server/cards.js
+++ b/server/cards.js
@@ -2,7 +2,8 @@ const uuidv4 = require('uuid').v4;
 
 // Constants
 const suits = ['spades', 'diamonds', 'clubs', 'hearts'];
-const values = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+// const values = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+const values = ['A', '2']; //, '3'], '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
 
 /**
  * Data format
@@ -33,15 +34,17 @@ const getDeck = (withJoker = true) => {
       deck.push(card);
     }
   }
-  // if (withJoker) {
-  //   const joker = {
-  //     id: uuidv4(),
-  //     value: 'Joker',
-  //     suit: null,
-  //     points: 10
-  //   };
-  //   deck.push(joker, joker);
-  // }
+  if (withJoker) {
+    for (let i = 0; i < 2; i++) {
+      const joker = {
+        id: uuidv4(),
+        value: 'Joker',
+        suit: null,
+        points: 10
+      };
+      deck.push(joker);
+    }
+  }
 
   return deck;
 };


### PR DESCRIPTION
Fix #65
Fix #60

This PR fixes the joker duplicated id which broke the drawPile.
It also fixes the exchange & swap actions. Before, both allowed swap of any cards of any players...  
It also adds a shaking animation on the card when the card is selected and restore the display of the failed card.