### PR TITLE
Fix CardSpot with more than 4 cards and one is missing

### DIFF
--- a/components/Game/PlayerCards/index.js
+++ b/components/Game/PlayerCards/index.js
@@ -9,7 +9,11 @@ const PlayerCards = ({ player, position }) => {
   const { cards, id: playerId } = player;
   const { nextAction, nextPlayer } = useCardActions();
   const { setCardSpotRef } = useCardSpots();
-  const spots = Array.apply(null, Array(Math.max(cards.length, 4)));
+  // Find maximum spot used
+  const [lastCard] = cards.sort((c1, c2) => (c1.spot > c2.spot ? 1 : -1)).slice(-1);
+  const nbrOfSpots = lastCard ? Math.max(parseInt(lastCard.spot.slice(-1)) + 1, 4) : 4;
+
+  const spots = Array.apply(null, Array(nbrOfSpots));
   const isPlayerToPlay = nextPlayer && nextAction && playerId === nextPlayer.id;
 
   return (

--- a/server/cards.js
+++ b/server/cards.js
@@ -2,8 +2,7 @@ const uuidv4 = require('uuid').v4;
 
 // Constants
 const suits = ['spades', 'diamonds', 'clubs', 'hearts'];
-// const values = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
-const values = ['A', '2']; //, '3'], '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+const values = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
 
 /**
  * Data format


### PR DESCRIPTION
This PR fixes an issue with the number of cardspots when the player has picked a fifth (or more) card and them throw one. 
Before, I counted the number of cards a player has. But, player can have a card at spot 5 and no card at spot 4. So the count was wrong.