### PR TITLE
Throw card with a double click

### DIFF
--- a/components/PlayingCard/_styled.js
+++ b/components/PlayingCard/_styled.js
@@ -32,7 +32,7 @@ export const PlayingCardInner = styled.div`
   width: 100%;
   position: relative;
   border-radius: ${theme.metric.borderRadius};
-  transition: transform 0.4s ease-in-out;
+  transition: transform 0.25s ease-in-out;
   transform-style: preserve-3d;
   will-change: transform;
 

--- a/components/PlayingCard/_styled.js
+++ b/components/PlayingCard/_styled.js
@@ -77,7 +77,7 @@ export const PlayingCardWrapper = styled.div`
         `}
 
   ${props =>
-    props.onClick &&
+    (props.onClick || props.onDoubleClick) &&
     css`
       &:hover {
         cursor: pointer;

--- a/components/PlayingCard/index.js
+++ b/components/PlayingCard/index.js
@@ -66,7 +66,7 @@ const PlayingCard = ({ card, className, isRotated = false }) => {
   // TODO: allow watch the top card of the draw pile
   const canWatch = isSelfToPlay && nextAction === 'watch' && isInPlayersHand;
 
-  const canPlay = canDiscover || canGive || canPick || canSelect || canThrow || canWatch;
+  const canPlay = canDiscover || canGive || canPick || canSelect || canWatch;
 
   return (
     <PlayingCardWrapper

--- a/components/PlayingCard/index.js
+++ b/components/PlayingCard/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import useCardActions from '../../hooks/useCardActions';
+import useClickPreventionOnDoubleClick from '../../hooks/useClickPreventionOnDoubleClick';
 import useCardSpots, {
   DISCARD_PILE_SPOT_ID,
   DRAW_PILE_SPOT_ID,
@@ -21,8 +22,12 @@ const SUIT_LETTER = {
 
 const PlayingCard = ({ card, className, isRotated = false }) => {
   const { cardSpots } = useCardSpots();
-  const { handleCardClick, isSelfToPlay, nextAction } = useCardActions();
+  const { handleCardClick, handleCardDoubleClick, isSelfToPlay, nextAction } = useCardActions();
   const { game, selectedCards, selfId, unfoldedCards } = useGame();
+  const [handleClick, handleDoubleClick] = useClickPreventionOnDoubleClick(
+    () => handleCardClick(card),
+    () => handleCardDoubleClick(card)
+  );
 
   const { id, isBeingWatchedBy, suit, value } = card;
   const suitLetter = SUIT_LETTER[suit];
@@ -53,9 +58,11 @@ const PlayingCard = ({ card, className, isRotated = false }) => {
   const canSelect =
     isSelfToPlay && (nextAction === 'exchange' || nextAction === 'swap') && isInPlayersHand;
   const canThrow =
-    (game.isStarted && !isSelfToPlay && isInPlayersHand) ||
-    (isSelfToPlay && nextAction === 'throw' && (isPickedCard || isInSelfPlayersHand)) ||
-    (isSelfToPlay && nextAction === 'pick' && isInPlayersHand);
+    game.isStarted &&
+    nextAction !== 'give' &&
+    nextAction !== 'pickFailed' &&
+    nextAction !== 'pickDrawAfterFail' &&
+    (isInPlayersHand || (nextAction === 'throw' && isSelfToPlay && isPickedCard));
   // TODO: allow watch the top card of the draw pile
   const canWatch = isSelfToPlay && nextAction === 'watch' && isInPlayersHand;
 
@@ -67,7 +74,9 @@ const PlayingCard = ({ card, className, isRotated = false }) => {
       isRotated={isRotated}
       isSelected={isSelected}
       isFailedCard={isFailedCard}
-      {...(canPlay ? { onClick: () => handleCardClick(card) } : {})}
+      {...(canPlay ? { onClick: handleClick } : {})}
+      {...(canThrow ? { onDoubleClick: handleDoubleClick } : {})}
+      {...(!canThrow && canPlay ? { onClick: () => handleCardClick(card) } : {})}
     >
       <PlayingCardInner isHidden={!isCardVisible}>
         {isBeingWatchedBy && isBeingWatchedBy !== selfId && <StyledEye src={'/assets/eye.svg'} />}

--- a/helpers/cancellablePromise.js
+++ b/helpers/cancellablePromise.js
@@ -1,0 +1,17 @@
+const cancellablePromise = promise => {
+  let isCanceled = false;
+
+  const wrappedPromise = new Promise((resolve, reject) => {
+    promise.then(
+      value => (isCanceled ? reject({ isCanceled, value }) : resolve(value)),
+      error => reject({ isCanceled, error })
+    );
+  });
+
+  return {
+    promise: wrappedPromise,
+    cancel: () => (isCanceled = true)
+  };
+};
+
+export default cancellablePromise;

--- a/helpers/delay.js
+++ b/helpers/delay.js
@@ -1,0 +1,3 @@
+const delay = n => new Promise(resolve => setTimeout(resolve, n));
+
+export default delay;

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -1,0 +1,2 @@
+export { default as cancellablePromise } from './cancellablePromise';
+export { default as delay } from './delay';

--- a/hooks/useCancellablePromises.js
+++ b/hooks/useCancellablePromises.js
@@ -1,0 +1,23 @@
+import { useRef } from 'react';
+
+const useCancellablePromises = () => {
+  const pendingPromises = useRef([]);
+
+  const appendPendingPromise = promise =>
+    (pendingPromises.current = [...pendingPromises.current, promise]);
+
+  const removePendingPromise = promise =>
+    (pendingPromises.current = pendingPromises.current.filter(p => p !== promise));
+
+  const clearPendingPromises = () => pendingPromises.current.map(p => p.cancel());
+
+  const api = {
+    appendPendingPromise,
+    removePendingPromise,
+    clearPendingPromises
+  };
+
+  return api;
+};
+
+export default useCancellablePromises;

--- a/hooks/useCardActions.js
+++ b/hooks/useCardActions.js
@@ -47,7 +47,6 @@ export const CardActionsProvider = ({ children }) => {
   }, [gameId, resetCards, selectedCards, selectedCardsCount]);
 
   const handleCardClick = card => {
-    console.log('handleCardClick');
     const isSelf = card.belongsTo === selfId;
 
     if (!isStarted) {
@@ -96,16 +95,25 @@ export const CardActionsProvider = ({ children }) => {
         return selectCard(card, nextAction);
       }
 
-      if (nextAction === 'throw' && card.spot === 'picked-card') {
-        return handleThrowPickedCard();
-      }
-
       if (nextAction === 'watch') {
         return !unfoldedCardsCount ? handleWatchCard(card) : handleHasWatchedCard(card);
       }
     }
-    // No action? the player want to throw the card then
-    return handleThrowCard(card);
+  };
+
+  const handleCardDoubleClick = card => {
+    const isSelf = card.belongsTo === selfId;
+
+    if (isStarted) {
+      if (nextAction === 'throw' && card.spot === 'picked-card') {
+        return handleThrowPickedCard();
+      }
+      if (nextAction === 'throw' && !isSelf) {
+        return;
+      }
+      // The player want to throw the card
+      return handleThrowCard(card);
+    }
   };
 
   const handleGiveCard = ({ id: cardId }) => {
@@ -186,6 +194,7 @@ export const CardActionsProvider = ({ children }) => {
     <CardActionsContext.Provider
       value={{
         handleCardClick,
+        handleCardDoubleClick,
         isSelfToPlay,
         nextAction,
         nextPlayer

--- a/hooks/useClickPreventionOnDoubleClick.js
+++ b/hooks/useClickPreventionOnDoubleClick.js
@@ -1,0 +1,33 @@
+import { cancellablePromise, delay } from '../helpers';
+import useCancellablePromises from './useCancellablePromises';
+
+const useClickPreventionOnDoubleClick = (onClick, onDoubleClick) => {
+  const api = useCancellablePromises();
+
+  const handleClick = () => {
+    api.clearPendingPromises();
+    const waitForClick = cancellablePromise(delay(175));
+    api.appendPendingPromise(waitForClick);
+
+    return waitForClick.promise
+      .then(() => {
+        api.removePendingPromise(waitForClick);
+        onClick();
+      })
+      .catch(errorInfo => {
+        api.removePendingPromise(waitForClick);
+        if (!errorInfo.isCanceled) {
+          throw errorInfo.error;
+        }
+      });
+  };
+
+  const handleDoubleClick = () => {
+    api.clearPendingPromises();
+    onDoubleClick();
+  };
+
+  return [handleClick, handleDoubleClick];
+};
+
+export default useClickPreventionOnDoubleClick;

--- a/server/game.js
+++ b/server/game.js
@@ -124,12 +124,14 @@ const givePlayerCard = (game, playerId, cardId) => {
   const { nextActions: oldActions, players } = game;
   // Find to whom player should give
   const [{ playerToAddACard }] = oldActions;
+  // Add card to player
+  const newGame = addCardToPlayer(game, playerToAddACard.id, cardId);
   const playerToRemoveACard = players[playerId];
 
   return {
-    ...addCardToPlayer(game, playerToAddACard.id, cardId),
+    ...newGame,
     players: {
-      ...players,
+      ...newGame.players,
       [playerToRemoveACard.id]: Player.removeCard(playerToRemoveACard, cardId)
     }
   };

--- a/server/game.js
+++ b/server/game.js
@@ -107,6 +107,11 @@ const isDone = game => {
   const { caracolePlayer, players: playersCollection, nextActions } = game;
 
   const [nextAction] = nextActions;
+
+  if (nextAction.action === 'give') {
+    return false;
+  }
+
   // If final round after calling caracol is done, game's end
   if (
     caracolePlayer &&

--- a/server/index.js
+++ b/server/index.js
@@ -175,10 +175,6 @@ io.on('connection', socket => {
 
     if (currentAction.player.id === playerId && currentAction.action === 'throw') {
       game = Game.setCardToDiscardPileAndReplaceByPickedCard(game, playerId, cardId);
-      // Check if game is done
-      if (Game.isDone(game)) {
-        game = Game.end(game);
-      }
     }
     // If a player throws his or someone's card
     else if (Game.isCardCanBeThrown(game, cardId)) {
@@ -188,6 +184,10 @@ io.on('connection', socket => {
     else {
       // Set the card to be visible by everyone
       game = Game.setCardAsFailedCard(game, playerId, cardId);
+    }
+    // Check if game is done
+    if (Game.isDone(game)) {
+      game = Game.end(game);
     }
     // Save
     FakeDB.saveGame(game);


### PR DESCRIPTION
This PR updates the gameplay by using a single click so all action except throwing.  This allows to throw more than one card in a row and at any time.

It also fixes the end game issue where a player couldn't finish by throwing his card.

Close #28
Close #62
