### PR TITLE
Fixes

### DIFF
--- a/components/PlayingCard/index.js
+++ b/components/PlayingCard/index.js
@@ -59,7 +59,8 @@ const PlayingCard = ({ card, className, isRotated = false }) => {
     isSelfToPlay && (nextAction === 'exchange' || nextAction === 'swap') && isInPlayersHand;
   const canThrow =
     game.isStarted &&
-    !isUnfolded &&
+    !selectedCards.length &&
+    !unfoldedCards.length &&
     nextAction !== 'give' &&
     nextAction !== 'pickFailed' &&
     nextAction !== 'pickDrawAfterFail' &&

--- a/components/PlayingCard/index.js
+++ b/components/PlayingCard/index.js
@@ -57,6 +57,8 @@ const PlayingCard = ({ card, className, isRotated = false }) => {
     (isSelfToPlay && nextAction === 'pickDrawAfterFail' && isInDrawPile);
   const canSelect =
     isSelfToPlay && (nextAction === 'exchange' || nextAction === 'swap') && isInPlayersHand;
+  const canThrowOncePicked =
+    isSelfToPlay && nextAction === 'throw' && (isPickedCard || isInSelfPlayersHand);
   const canThrow =
     game.isStarted &&
     !selectedCards.length &&
@@ -64,11 +66,14 @@ const PlayingCard = ({ card, className, isRotated = false }) => {
     nextAction !== 'give' &&
     nextAction !== 'pickFailed' &&
     nextAction !== 'pickDrawAfterFail' &&
-    (isInPlayersHand || (nextAction === 'throw' && isSelfToPlay && isPickedCard));
+    isInPlayersHand &&
+    // Player can't throw card when he has a picked card
+    !(nextAction === 'throw' && isSelfToPlay);
+
   // TODO: allow watch the top card of the draw pile
   const canWatch = isSelfToPlay && nextAction === 'watch' && isInPlayersHand;
 
-  const canPlay = canDiscover || canGive || canPick || canSelect || canWatch;
+  const canPlay = canDiscover || canGive || canPick || canSelect || canThrowOncePicked || canWatch;
 
   return (
     <PlayingCardWrapper

--- a/hooks/useCardActions.js
+++ b/hooks/useCardActions.js
@@ -96,7 +96,13 @@ export const CardActionsProvider = ({ children }) => {
       }
 
       if (nextAction === 'watch') {
-        return !unfoldedCardsCount ? handleWatchCard(card) : handleHasWatchedCard(card);
+        if (!unfoldedCardsCount) {
+          return handleWatchCard(card);
+        }
+        // Fold only unfolded card
+        if (unfoldedCards.find(c => c.id === card.id)) {
+          return handleHasWatchedCard(card);
+        }
       }
     }
   };

--- a/hooks/useCardActions.js
+++ b/hooks/useCardActions.js
@@ -91,6 +91,14 @@ export const CardActionsProvider = ({ children }) => {
         return handlePickDrawCardAfterFail();
       }
 
+      if (nextAction === 'throw' && card.spot === 'picked-card') {
+        return handleThrowPickedCard();
+      }
+
+      if (nextAction === 'throw' && isSelf) {
+        return handleThrowCard(card);
+      }
+
       if (nextAction === 'exchange' || nextAction === 'swap') {
         return selectCard(card, nextAction);
       }
@@ -109,11 +117,7 @@ export const CardActionsProvider = ({ children }) => {
 
   const handleCardDoubleClick = card => {
     const isSelf = card.belongsTo === selfId;
-
     if (isStarted) {
-      if (nextAction === 'throw' && card.spot === 'picked-card') {
-        return handleThrowPickedCard();
-      }
       if (nextAction === 'throw' && !isSelf) {
         return;
       }


### PR DESCRIPTION
This PR fixes few issues: 
- Remove throwing while a card is already selected during an swap/exchange;
- Remove throwing of other players cards if player has already picked a card;
- Fold is mandatory to unfold a second card;
- Use double click only for quick throw.

Close #81 
Close #82 