### PR TITLE
Fix exchange between picked & player cards

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -282,8 +282,7 @@ const setCardToDiscardPileAndReplaceByPickedCard = (game, playerId, cardId) => {
   }
 
   // Add picked card to player
-  player = Player.removeCard(player, cardToThrow.id);
-  player = Player.addCard(player, pickedCard);
+  player = Player.replaceCard(player, cardToThrow.id, pickedCard);
   // Remove action of throw
   oldActions = oldActions.slice(1);
   // Get next player to pick
@@ -605,12 +604,10 @@ const swapPlayersCards = (game, cardIdsToSwap) => {
   };
 
   let player1 = players[cardForPlayer1.belongsTo];
-  player1 = Player.removeCard(player1, cardFromPlayer1.id);
-  player1 = Player.addCard(player1, cardForPlayer1);
+  player1 = Player.replaceCard(player1, cardFromPlayer1.id, cardForPlayer1);
 
   let player2 = players[cardForPlayer2.belongsTo];
-  player2 = Player.removeCard(player2, cardFromPlayer2.id);
-  player2 = Player.addCard(player2, cardForPlayer2);
+  player2 = Player.replaceCard(player2, cardFromPlayer2.id, cardForPlayer2);
 
   if (!player1 || !player2 || !cardFromPlayer1 || !cardForPlayer2) {
     return game;

--- a/server/player.js
+++ b/server/player.js
@@ -58,10 +58,25 @@ const create = (name, isCreator = false) => ({
 
 const isDone = player => !player.cards.length;
 
-const removeCard = (player, cardId) => {
+const removeCard = (player, cardId) => ({
+  ...player,
+  cards: player.cards.filter(card => card.id !== cardId)
+});
+
+const replaceCard = (player, cardIdToReplace, cardToAdd) => {
+  const { spot } = player.cards.find(c => c.id === cardIdToReplace);
+  const cards = player.cards.filter(card => card.id !== cardIdToReplace);
+
   return {
     ...player,
-    cards: player.cards.filter(card => card.id !== cardId)
+    cards: [
+      ...cards,
+      {
+        ...cardToAdd,
+        belongsTo: player.id,
+        spot
+      }
+    ]
   };
 };
 
@@ -81,6 +96,7 @@ module.exports = {
   create,
   isDone,
   removeCard,
+  replaceCard,
   setHasDiscoveredHisCards,
   setIsReady
 };


### PR DESCRIPTION
There was an issue when a player has the 5th (or more) spot filled and he has a missing card in his hand. If  he picks a card and exchange it with a card in his hand, the card from the draw pile and the player cards are desynchronised which broke the layout. 

This PR fixes that by always replacing the new card as the previous card's spot. 